### PR TITLE
Listeners

### DIFF
--- a/custom_components/inels/base_class.py
+++ b/custom_components/inels/base_class.py
@@ -2,9 +2,6 @@
 from __future__ import annotations
 
 from typing import Any
-
-from inelsmqtt.devices import Device
-
 from homeassistant.helpers.entity import DeviceInfo, Entity
 
 from .const import DOMAIN
@@ -15,10 +12,10 @@ class InelsBaseEntity(Entity):
 
     def __init__(
         self,
-        device: Device,
+        device: Any,
     ) -> None:
         """Init base entity."""
-        self._device: Device = device
+        self._device: Any = device
         self._device_id = self._device.unique_id
         self._attr_name = self._device.title
 

--- a/custom_components/inels/button.py
+++ b/custom_components/inels/button.py
@@ -38,7 +38,7 @@ async def async_setup_entry(
     entities = []
 
     for device in device_list:
-        if device.device_type == Platform.BUTTON:
+        if device.device_type.value == Platform.BUTTON:
             index = 1
             val = device.get_value()
             if val.ha_value is not None:

--- a/custom_components/inels/climate.py
+++ b/custom_components/inels/climate.py
@@ -41,7 +41,7 @@ async def async_setup_entry(
         [
             InelsClimate(device)
             for device in device_list
-            if device.device_type == Platform.CLIMATE
+            if device.device_type.value == Platform.CLIMATE
         ],
     )
 

--- a/custom_components/inels/cover.py
+++ b/custom_components/inels/cover.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from inelsmqtt.const import RFJA_12, SHUTTER_STATE_LIST, STOP_DOWN, STOP_UP
+from inelsmqtt.const import SHUTTER_STATE_LIST, STOP_DOWN, STOP_UP, Element
 from inelsmqtt.devices import Device
 
 from homeassistant.components.cover import CoverDeviceClass, CoverEntity
@@ -28,7 +28,7 @@ async def async_setup_entry(
         [
             InelsCover(device)
             for device in device_list
-            if device.device_type == Platform.COVER
+            if device.device_type.value == Platform.COVER
         ],
     )
 
@@ -40,7 +40,7 @@ class InelsCover(InelsBaseEntity, CoverEntity):
         """Initialize a cover."""
         super().__init__(device=device)
 
-        if self._device.inels_type is RFJA_12:
+        if self._device.inels_type.value is Element.RFJA_12:
             self._attr_device_class = CoverDeviceClass.SHUTTER
         else:
             self._attr_device_class = CoverDeviceClass.SHUTTER

--- a/custom_components/inels/manifest.json
+++ b/custom_components/inels/manifest.json
@@ -6,7 +6,7 @@
   "issue_tracker": "https://github.com/Nejezchleb/inels-hacs-temp/issues",
   "documentation": "https://github.com/Nejezchleb/inels-hacs-temp",
   "requirements": [
-    "inels-mqtt==0.0.55"
+    "inels-mqtt==0.0.60"
   ],
   "dependencies": [
     "mqtt"

--- a/custom_components/inels/switch.py
+++ b/custom_components/inels/switch.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from typing import Any
-
-from inelsmqtt.devices import Device
+from inelsmqtt.devices.switch import Switch
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -22,41 +21,33 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Load Inels switch.."""
-    device_list = hass.data[DOMAIN][config_entry.entry_id][DEVICES]
+    device_list: list[Switch] = [
+        dev
+        for dev in hass.data[DOMAIN][config_entry.entry_id][DEVICES]
+        if dev.device_type.value == Platform.SWITCH
+    ]
 
-    async_add_entities(
-        [
-            InelsSwitch(device)
-            for device in device_list
-            if device.device_type == Platform.SWITCH
-        ],
-    )
+    switches = [InelsSwitch(device) for device in device_list]
+
+    async_add_entities(switches)
 
 
 class InelsSwitch(InelsBaseEntity, SwitchEntity):
     """The platform class required by Home Assistant."""
 
-    def __init__(self, device: Device) -> None:
+    def __init__(self, device: Switch) -> None:
         """Initialize a switch."""
         super().__init__(device=device)
 
-        self._state_attrs = None
-
-        if isinstance(device.state, bool) is False:
-            if hasattr(device.state, "on"):
-                self._state_attrs = {
-                    ATTR_TEMPERATURE: device.state.temperature,
-                    "on": device.state.on,
-                }
+        self._state_attrs = {}
+        self.set_state_attrs(self._device.features)
 
     @property
     def is_on(self) -> bool:
         """Return true if switch is on."""
-        if isinstance(self._device.state, bool) is False:
-            if hasattr(self._device.state, "on"):
-                return self._device.state.on
+        state = self._device.state
 
-        return self._device.state
+        return state.on
 
     @property
     def icon(self) -> str | None:
@@ -82,11 +73,16 @@ class InelsSwitch(InelsBaseEntity, SwitchEntity):
             return None
         await self.hass.async_add_executor_job(self._device.set_ha_value, True)
 
+    def set_state_attrs(self, features: dict[str, Any]) -> None:
+        """Set state attributes."""
+        if features is None:
+            return
+
+        for feature in features:
+            self._state_attrs[feature] = self._device.state.__dict__.get(feature)
+
     def _callback(self, new_value: Any) -> None:
         """Get callback data from the broker."""
-        if self._state_attrs is not None:
-            if isinstance(self._device.state, bool) is False:
-                self._state_attrs[ATTR_TEMPERATURE] = self._device.state.temperature
-                self._state_attrs["on"] = self._device.state.on
+        self.set_state_attrs(self._device.features)
 
         super()._callback(new_value)

--- a/custom_components/inels/water_heater.py
+++ b/custom_components/inels/water_heater.py
@@ -48,7 +48,7 @@ async def async_setup_entry(
         [
             InelsWaterHeater(device)
             for device in device_list
-            if device.device_type == Platform.WATER_HEATER
+            if device.device_type.value == Platform.WATER_HEATER
         ],
     )
 


### PR DESCRIPTION
-- features outside of the inels-mqtt library
-- new classes no Device at all is initialized
-- new dicts in const with Platform and Entities to better usages
- listeners on two stages. First from mqtt lib to device class and second from device class to outside of the inels-mqtt lib. In our case it is HA platforms
- listeners registerd in InelsBaseEntity
-- change defining unique ID especially in sensors where description is used and every description has own listener